### PR TITLE
Imagem específica para documentação do assistente

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -311,6 +311,21 @@ services:
             traefik.alias: assistente
         networks:
             rl:
+            
+    assistente_docs:
+        image: assistente:docs
+        ports:
+            - "3001:80"
+        build: ../Assistente
+        volumes:
+            - ./log/assistente_docs:/var/log/assistente_docs
+        labels:
+            traefik.frontend.rule: Host:docs.assistente.redelivre"
+            traefik.port: '80'
+            traefik.enable: 'true'
+            traefik.alias: assistente_docs
+        networks:
+            rl:
 
     # composer:
     #     image: composer

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -316,7 +316,9 @@ services:
         image: assistente:docs
         ports:
             - "3001:80"
-        build: ../Assistente
+        build: 
+            context: ../Assistente
+            dockerfile: Dockerfile.docs
         volumes:
             - ./log/assistente_docs:/var/log/assistente_docs
         labels:


### PR DESCRIPTION
A documentação do app [Assistente](https://github.com/lunhg/Assistente/tree/master/docs) será composta como um [container](https://github.com/lunhg/Assistente/blob/master/Dockerfile.docs) de um simples servidor python que serve arquivos estáticos.  

O servidor em questão é:

    $ python -m SimpleHTTPServer 3001